### PR TITLE
chore: add CI and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,28 @@
+name: Release-plz
+# see https://release-plz.ieni.dev/docs/github/quickstart for more information
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The CI workflow is just a minimal one

The release workflow uses release-plz. If you haven't used it before, it's fairly simple. When you push changes to the main branch, it automatically keeps a CHANGELOG in sync with the changes and cuts a PR with an update to the CHANGELOG and version. Merging that PR automatically triggers a release of the project to crates.io.

You can see this in action in https://github.com/joshka/tui-big-text/pull/21 - it's very easy to set and forget.

To enable this release workflow can you please:
1. Enable "Allow GitHub Actions to create and approve pull requests" (last checkbox at https://github.com/azorng/material/settings/actions)
2. Create a crate publish token at https://crates.io/settings/tokens. The token should have publish-update scope (it only needs to select this crate if you have multiple crates)
3. Add a new Repository secret named `CARGO_REGISTRY_TOKEN` at https://github.com/azorng/material/settings/secrets/actions with the token value