### PR TITLE
feat: use key 'T' to display colors as foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ cargo install material --locked --features=cli
 ## Usage
 
 Run the command ``material`` in the terminal.
-Type the color code to copy its hex color to the clipboard. Type Esc to exit.
+Type the color code to copy its hex color to the clipboard.
+Type <kbd>T</kbd> to toggle between colors displayed as background or foreground.
+Type <kbd>Esc</kbd> to exit.
 
 ## As a library
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,8 @@ pub struct App {
     pub message: String,
     pub input: String,
     pub colors: &'static Colors,
+    /// Show each color as foreground (true) instead of background (false)
+    pub color_fg: bool,
 }
 
 impl App {
@@ -14,16 +16,21 @@ impl App {
             message: String::new(),
             input: String::new(),
             colors: &COLOR_DATA,
+            color_fg: false,
         }
     }
 
     pub fn handle_input(&mut self, c: char) {
-        if self.input.len() == 2 {
-            self.input = String::new();
-        }
-        self.input.push(c);
-        if self.input.len() == 2 {
-            self.color_search();
+        if c == 't' || c == 'T' {
+            self.color_fg = !self.color_fg;
+        } else {
+            if self.input.len() == 2 {
+                self.input = String::new();
+            }
+            self.input.push(c);
+            if self.input.len() == 2 {
+                self.color_search();
+            }
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -26,9 +26,14 @@ pub fn ui(f: &mut Frame, app: &App) {
             } else {
                 Color::White
             };
+            let style = if app.color_fg {
+                Style::default().fg(bg_color)
+            } else {
+                Style::default().bg(bg_color).fg(text_color)
+            };
             f.render_widget(
                 Block::default()
-                    .style(Style::default().bg(bg_color).fg(text_color))
+                    .style(style)
                     .title(color_var.0)
                     .title_alignment(Alignment::Center),
                 Rect::new(pos.0, pos.1, sq_width, sq_height),


### PR DESCRIPTION
Colors render differently when used as background or foreground (surface differs).

Using the 'T' touch, the user can toggle the display between the standard rendering (palette color rendered as background) and a new rendering where palette colors are rendered as foreground colors on default background color.